### PR TITLE
fix for external client only scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,18 @@ To use PSRAM for internal memory allocation which you can config to use it via [
 #define ESP_GOOGLE_SHEET_CLIENT_USE_PSRAM
 ```
 
+### Usage with TinyGSM
+By default the library assumes a working native WiFi or Ethernet connection. When using TinyGSM as an external client, you most likely do not want to use the Wifi/Ethernet (i.e. to get the current time). You will have to disable this in [**ESP_Google_Sheet_Client_FS_Config.h**](src/ESP_Google_Sheet_Client_FS_Config.h) by uncommenting the following lines like this:
+```cpp
+/* If not use on-board WiFi */
+#define ESP_GOOGLE_SHEET_CLIENT_DISABLE_ONBOARD_WIFI
+
+/* If not use native Ethernet (Ethernet interfaces that supported by SDK) */
+#define ESP_GOOGLE_SHEET_CLIENT_DISABLE_NATIVE_ETHERNET
+```
+Also, check out the [GSM Example](examples/GSM/GSM.ino) for more information.
+
+
 ## Functions Description
 
 ### Global Functions

--- a/src/ESP_Google_Sheet_Client.cpp
+++ b/src/ESP_Google_Sheet_Client.cpp
@@ -68,7 +68,7 @@ void GSheetClass::auth(const char *client_email, const char *project_id, const c
 #endif
     }
 
-#if defined(ESP32) || defined(ESP8266)
+#if defined(ESP_GOOGLE_SHEET_CLIENT_WIFI_IS_AVAILABLE)
     config.internal.reconnect_wifi = WiFi.getAutoReconnect();
 #endif
     config.signer.tokens.token_type = token_type_oauth2_access_token;


### PR DESCRIPTION
Hi, sorry to bug you again, but i did some more debugging after your comment [here](https://github.com/mobizt/ESP-Google-Sheet-Client/issues/4#issuecomment-1921164301) - then I found out I had to explicitly tell the library to disable wifi and ethernet in `src/ESP_Google_Sheet_client_FS_Config.h` (I uncommented the following lines):
```
/* If not use on-board WiFi */
#define ESP_GOOGLE_SHEET_CLIENT_DISABLE_ONBOARD_WIFI

/* If not use native Ethernet (Ethernet interfaces that supported by SDK) */
#define ESP_GOOGLE_SHEET_CLIENT_DISABLE_NATIVE_ETHERNET
```

But now the library was not compiling properly and I had to change a `#ifdef` in order for it to compile properly (see changes). 

I also took the liberty of updating the README to explicitly underline this feature :)

Again, much kudos to your work on all your ESP libraries, they are really good and helpful!

