### PR TITLE
avoid multiple definitions for spi using extern and inline for SDSD_C…

### DIFF
--- a/src/GS_SDHelper.h
+++ b/src/GS_SDHelper.h
@@ -32,7 +32,7 @@ SdSpiConfig sdFatSPIConfig(SPI_CS_PIN, DEDICATED_SPI, SD_SCK_MHZ(SPI_CLOCK_IN_MH
 
 #elif defined(ESP32) // if ESP32 and no SdFat library installed
 
-SPIClass spi;
+extern SPIClass spi;
 
 #elif defined(ESP8266)
 
@@ -52,7 +52,7 @@ SDFSConfig sdFSConfig(SPI_CS_PIN, SPI_HALF_SPEED, SPI1);
 
 #endif
 
-bool SD_Card_Mounting()
+inline bool SD_Card_Mounting()
 {
 
 #if defined(DEFAULT_SD_FS) && defined(CARD_TYPE_SD)


### PR DESCRIPTION
Was getting multiple definition errors for a large code I am doing. `SPIClass spi;` and `SD_Card_Mounting()` were being defined multiple times. So I used `extern` and `inline` for those.

Original errors:
.pio/build/lolin_s3_mini/src/main.cpp.o:/Users/xxxx/Documents/PlatformIO/Precision Wattmeter ESP32 S3/.pio/libdeps/lolin_s3_mini/ESP-Google-Sheet-Client/src/GS_SDHelper.h:35: **multiple definition of `spi`;** 
.pio/libdeps/lolin_s3_mini/ESP-Google-Sheet-Client/src/GS_SDHelper.h:35: first defined here
/Users/prithul0218/.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/8.4.0/../../../../xtensa-esp32s3-elf/bin/ld: .pio/build/lolin_s3_mini/src/main.cpp.o: in function `SD_Card_Mounting()`:
/Users/prithul0218/Documents/PlatformIO/Precision Wattmeter ESP32 S3/.pio/libdeps/lolin_s3_mini/ESP-Google-Sheet-Client/src/GS_SDHelper.h:56: **multiple definition of `SD_Card_Mounting()';** 